### PR TITLE
Updating target image to handle shadow data

### DIFF
--- a/Components/GameBoard/AbilityTargeting.jsx
+++ b/Components/GameBoard/AbilityTargeting.jsx
@@ -21,7 +21,8 @@ class AbilityTargeting extends React.Component {
                 onMouseOver={ event => this.onMouseOver(event, card) }>
                 <img className='target-card-image vertical'
                     alt={ card.name }
-                    src={ '/img/cards/' + (!card.facedown ? (card.code + '.png') : 'cardback.jpg') } />
+                    src={ '/img/cards/' + (card.facedown ? (card.shadowPosition ? 'cardback_shadow.png' : 'cardback.jpg') : card.code + '.png') } />
+                { card.shadowPosition ? <div className='target-card-shadow-position'>{ '#' + card.shadowPosition }</div> : null }
             </div>);
     }
 

--- a/less/gameboard.less
+++ b/less/gameboard.less
@@ -455,12 +455,21 @@
   margin: 0 2px;
   max-height: @card-height;
   max-width: @card-width;
+  position: relative;
 }
 
 .target-card-image {
   max-height: @card-height;
   object-fit: contain;
   width: 100%;
+}
+
+.target-card-shadow-position {
+  position: absolute;
+  line-height: 1em;
+  user-select: none;
+  bottom: 0%;
+  right: 5%;
 }
 
 .phase-indicator {


### PR DESCRIPTION
Shadow cards will now show the shadow cardback image, and will show the position that card is in.

Example:
![image](https://github.com/throneteki-playtesting/throneteki-client/assets/23492047/9089b222-6580-4eda-b568-8474bf347c1c)
